### PR TITLE
Resources for operator release 18.0.1

### DIFF
--- a/kubernetes/kubernetes.yml
+++ b/kubernetes/kubernetes.yml
@@ -3,20 +3,20 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+    app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
   labels:
+    app.kubernetes.io/version: 18.0.1
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
   name: keycloak-operator
 ---
 apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+    app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
   name: keycloak-operator
 spec:
   ports:
@@ -25,7 +25,7 @@ spec:
       targetPort: 8080
   selector:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
   type: ClusterIP
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -178,24 +178,24 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+    app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
   labels:
+    app.kubernetes.io/version: 18.0.1
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
   name: keycloak-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/version: 18.0.1
       app.kubernetes.io/name: keycloak-operator
-      app.kubernetes.io/version: 18.0.0
   template:
     metadata:
       annotations:
-        app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+        app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
       labels:
+        app.kubernetes.io/version: 18.0.1
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 18.0.0
     spec:
       containers:
         - env:
@@ -204,8 +204,8 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: OPERATOR_KEYCLOAK_IMAGE
-              value: quay.io/keycloak/keycloak:18.0.0
-          image: quay.io/keycloak/keycloak-operator:18.0.0
+              value: quay.io/keycloak/keycloak:18.0.1
+          image: quay.io/keycloak/keycloak-operator:18.0.1
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/kubernetes/minikube.yml
+++ b/kubernetes/minikube.yml
@@ -3,20 +3,20 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+    app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
   name: keycloak-operator
 ---
 apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+    app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
   name: keycloak-operator
 spec:
   ports:
@@ -26,7 +26,7 @@ spec:
       targetPort: 8080
   selector:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
   type: NodePort
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -34,7 +34,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
   name: keycloak-operator-view
 roleRef:
   kind: ClusterRole
@@ -112,24 +112,24 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+    app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
   name: keycloak-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: keycloak-operator
-      app.kubernetes.io/version: 18.0.0
+      app.kubernetes.io/version: 18.0.1
   template:
     metadata:
       annotations:
-        app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+        app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
       labels:
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 18.0.0
+        app.kubernetes.io/version: 18.0.1
     spec:
       containers:
         - env:
@@ -138,8 +138,8 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: OPERATOR_KEYCLOAK_IMAGE
-              value: quay.io/keycloak/keycloak:18.0.0
-          image: quay.io/keycloak/keycloak-operator:18.0.0
+              value: quay.io/keycloak/keycloak:18.0.1
+          image: quay.io/keycloak/keycloak-operator:18.0.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3

--- a/kubernetes/openshift.yml
+++ b/kubernetes/openshift.yml
@@ -4,10 +4,10 @@ kind: ServiceAccount
 metadata:
   annotations:
     app.openshift.io/vcs-url: <<unknown>>
-    app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+    app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
     app.openshift.io/runtime: quarkus
   name: keycloak-operator
 ---
@@ -16,10 +16,10 @@ kind: Service
 metadata:
   annotations:
     app.openshift.io/vcs-url: <<unknown>>
-    app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+    app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
     app.openshift.io/runtime: quarkus
   name: keycloak-operator
 spec:
@@ -29,7 +29,7 @@ spec:
       targetPort: 8080
   selector:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
   type: ClusterIP
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -37,7 +37,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
   name: keycloak-operator-view
 roleRef:
   kind: ClusterRole
@@ -76,10 +76,10 @@ kind: ImageStream
 metadata:
   annotations:
     app.openshift.io/vcs-url: <<unknown>>
-    app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+    app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
     app.openshift.io/runtime: quarkus
   name: keycloak-operator
 spec:
@@ -130,26 +130,26 @@ kind: DeploymentConfig
 metadata:
   annotations:
     app.openshift.io/vcs-url: <<unknown>>
-    app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+    app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
+    app.kubernetes.io/version: 18.0.1
     app.openshift.io/runtime: quarkus
   name: keycloak-operator
 spec:
   replicas: 1
   selector:
+    app.kubernetes.io/version: 18.0.1
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 18.0.0
   template:
     metadata:
       annotations:
         app.openshift.io/vcs-url: <<unknown>>
-        app.quarkus.io/build-timestamp: 2022-04-21 - 08:45:16 +0000
+        app.quarkus.io/build-timestamp: 2022-06-17 - 10:24:55 +0000
       labels:
         app.openshift.io/runtime: quarkus
+        app.kubernetes.io/version: 18.0.1
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 18.0.0
     spec:
       containers:
         - env:
@@ -158,8 +158,8 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: OPERATOR_KEYCLOAK_IMAGE
-              value: quay.io/keycloak/keycloak:18.0.0
-          image: quay.io/keycloak/keycloak-operator:18.0.0
+              value: quay.io/keycloak/keycloak:18.0.1
+          image: quay.io/keycloak/keycloak-operator:18.0.1
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3
@@ -194,5 +194,5 @@ spec:
           - keycloak-operator
         from:
           kind: ImageStreamTag
-          name: keycloak-operator:18.0.0
+          name: keycloak-operator:18.0.1
       type: ImageChange


### PR DESCRIPTION
After this is merged, we need to create a `18.0.1` tag.